### PR TITLE
Update ui with shadcn and background

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "about-me",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-slot": "^1.2.3",
         "next": "15.5.2",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -963,6 +964,39 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1308,7 +1342,7 @@
       "version": "19.1.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2382,7 +2416,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
+    "next": "15.5.2",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.5.2"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,50 +1,54 @@
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
 export default function Home() {
   return (
     <section className="relative min-h-screen flex items-center">
-      {/* Decorative background */}
-      <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(50%_50%_at_50%_0%,rgba(120,119,198,0.12)_0%,rgba(255,255,255,0)_60%)] dark:bg-[radial-gradient(50%_50%_at_50%_0%,rgba(120,119,198,0.15)_0%,rgba(10,10,10,0)_60%)]" />
+      {/* Abstract decorative background */}
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        {/* soft radial glow */}
+        <div className="absolute inset-0 bg-[radial-gradient(60%_50%_at_50%_-10%,rgba(120,119,198,0.18)_0%,rgba(255,255,255,0)_60%)] dark:bg-[radial-gradient(60%_50%_at_50%_-10%,rgba(120,119,198,0.22)_0%,rgba(10,10,10,0)_60%)]" />
+        {/* aurora blobs */}
+        <div className="absolute left-1/2 top-1/3 h-56 w-56 -translate-x-1/2 rounded-full bg-fuchsia-500/25 blur-[80px]" />
+        <div className="absolute left-[15%] top-[65%] h-40 w-40 rounded-full bg-indigo-500/20 blur-[70px]" />
+        <div className="absolute right-[10%] top-[20%] h-44 w-44 rounded-full bg-rose-500/20 blur-[70px]" />
+        {/* subtle grid */}
+        <div className="absolute inset-0 [background-image:linear-gradient(to_right,rgba(120,119,198,0.06)_1px,transparent_1px),linear-gradient(to_bottom,rgba(120,119,198,0.06)_1px,transparent_1px)] [background-size:24px_24px] [mask-image:radial-gradient(ellipse_at_center,black_40%,transparent_70%)]" />
+      </div>
 
       <div className="mx-auto w-full max-w-7xl px-6 md:px-10">
         <div className="max-w-4xl">
-          <span className="inline-flex items-center gap-2 rounded-full border border-foreground/15 bg-foreground/[.04] px-3 py-1 text-xs font-medium text-foreground/70">
-            Frontend Developer
-          </span>
+          <Badge>Frontend Developer</Badge>
 
           <h1 className="mt-6 text-4xl font-semibold tracking-tight sm:text-5xl md:text-6xl">
             Привіт! Я — фронтенд‑розробник
             <br />
             <span className="bg-gradient-to-r from-indigo-500 via-fuchsia-500 to-rose-500 bg-clip-text text-transparent">
-              з понад 1 роком досвіду
+              створюю сучасні веб‑інтерфейси
             </span>
             .
           </h1>
 
           <p className="mt-6 text-base/7 text-foreground/80 sm:text-lg/8">
-            Працюю з React, Next.js, TypeScript та Tailwind CSS. Створюю швидкі,
-            адаптивні та доступні інтерфейси з акцентом на чистий код і сучасний
-            дизайн.
+            Працюю з React, Next.js, TypeScript та Tailwind CSS. Зосереджуюся на
+            продуктивності, адаптивності та зручності користування з акцентом на
+            чистий і підтримуваний код.
           </p>
 
           <div className="mt-8 flex flex-wrap items-center gap-3">
-            <a
-              href="#projects"
-              className="inline-flex h-11 items-center justify-center rounded-full bg-foreground px-6 text-sm font-medium text-background shadow-sm transition-colors hover:opacity-90"
-            >
-              Переглянути проєкти
-            </a>
-            <a
-              href="#contact"
-              className="inline-flex h-11 items-center justify-center rounded-full border border-foreground/20 bg-transparent px-6 text-sm font-medium text-foreground/90 transition-colors hover:bg-foreground/[.04]"
-            >
-              Зв’затися
-            </a>
+            <Button asChild>
+              <a href="#projects">Переглянути проєкти</a>
+            </Button>
+            <Button variant="outline" asChild>
+              <a href="#contact">Зв’язатися</a>
+            </Button>
           </div>
 
           <div className="mt-10 flex flex-wrap gap-2 text-sm text-foreground/70">
-            <span className="rounded-full border border-foreground/15 bg-foreground/[.04] px-3 py-1">React</span>
-            <span className="rounded-full border border-foreground/15 bg-foreground/[.04] px-3 py-1">Next.js</span>
-            <span className="rounded-full border border-foreground/15 bg-foreground/[.04] px-3 py-1">TypeScript</span>
-            <span className="rounded-full border border-foreground/15 bg-foreground/[.04] px-3 py-1">Tailwind CSS</span>
+            <Badge>React</Badge>
+            <Badge>Next.js</Badge>
+            <Badge>TypeScript</Badge>
+            <Badge>Tailwind CSS</Badge>
           </div>
         </div>
       </div>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type BadgeProps = React.HTMLAttributes<HTMLSpanElement>;
+
+export function Badge({ className, ...props }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full border border-foreground/15 bg-foreground/[.04] px-3 py-1 text-xs font-medium text-foreground/70",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { Slot } from "@radix-ui/react-slot";
+
+export type ButtonVariant =
+  | "default"
+  | "outline"
+  | "ghost"
+  | "secondary";
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  asChild?: boolean;
+}
+
+const baseStyles =
+  "inline-flex items-center justify-center rounded-full text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 h-11 px-6";
+
+const variantStyles: Record<ButtonVariant, string> = {
+  default:
+    "bg-foreground text-background shadow-sm hover:opacity-90 focus-visible:ring-foreground/30",
+  outline:
+    "border border-foreground/20 bg-transparent text-foreground/90 hover:bg-foreground/[.04]",
+  ghost:
+    "bg-transparent text-foreground/90 hover:bg-foreground/[.04]",
+  secondary:
+    "bg-foreground/90 text-background hover:bg-foreground",
+};
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "default", asChild = false, ...props }, ref) => {
+    const Comp = (asChild ? Slot : ("button" as const)) as React.ElementType;
+    return (
+      <Comp
+        ref={ref}
+        className={cn(baseStyles, variantStyles[variant], className)}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+export function cn(
+  ...inputs: Array<string | undefined | null | false>
+): string {
+  return inputs.filter(Boolean).join(" ");
+}
+


### PR DESCRIPTION
Implement shadcn/ui components, replace experience mention, and add an abstract background to the hero section.

---
<a href="https://cursor.com/background-agent?bcId=bc-cebabfa0-576c-4755-a898-6a0ae983b6e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cebabfa0-576c-4755-a898-6a0ae983b6e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

